### PR TITLE
add support for Alpha Half-Life sprites

### DIFF
--- a/HL Texture Tools/HLTools/SpriteLoader.cs
+++ b/HL Texture Tools/HLTools/SpriteLoader.cs
@@ -134,7 +134,16 @@ namespace HLTools
 
             spriteHeader.Version = binReader.ReadInt32();
             spriteHeader.Type = (SprType)binReader.ReadInt32();
-            spriteHeader.TextFormat = (SprTextFormat)binReader.ReadInt32();
+            if (spriteHeader.Version != 1)
+            {
+                spriteHeader.TextFormat = (SprTextFormat)binReader.ReadInt32();
+            }
+            else
+            {
+                // for alpha Half-Life (<<NOT QUAKE>>) just use normal type TextFormat
+                // Quake is quite different to the alpha when it comes to sprites
+                spriteHeader.TextFormat = SprTextFormat.SPR_NORMAL;
+            }
             spriteHeader.BoundingRadius = binReader.ReadSingle();
             spriteHeader.MaxWidth = binReader.ReadInt32();
             spriteHeader.MaxHeight = binReader.ReadInt32();


### PR DESCRIPTION
This pull request adds read-only support for Alpha Half-Life sprites. Tested on `valve/sprites/bubbles.spr` from [this source on Archive.org](https://archive.org/download/half-lifeprototypes/Half-Life%20Prototypes/Half-Life/Half-Life%200.52.zip/Half-Life%200.52%2FHalf-Life%2Fvalve%2Fsprites%2Fbubble.spr).

Simply ignores a property they had not implemented at the time, based off the [Quake header structure](https://github.com/id-Software/Quake/blob/master/QW/client/spritegn.h).